### PR TITLE
Using more price data + small algo corrections

### DIFF
--- a/src/LiquidityRangeChart/hooks/useInitialView.tsx
+++ b/src/LiquidityRangeChart/hooks/useInitialView.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, RefObject } from 'react';
 import * as d3 from 'd3';
 import { LiquidityDataPoint, PriceDataPoint } from 'LiquidityRangeChart/types';
 import { ChartState } from './useChartState';
-import { computePriceBands, Years, DEFAULT_SIGMA, DEFAULT_ALPHA, DEFAULT_MU } from '../utils/bandFinder';
+import { computePriceBands, Years, DEFAULT_ALPHA, calculateMuAndVolatility } from '../utils/bandFinder';
 
 export function useInitialView(data: PriceDataPoint[], liquidityData: LiquidityDataPoint[], setChartState: (state: ChartState) => void, defaultState: RefObject<ChartState>, timeHorizonWeeks: number = 1) {
   const [initialViewSet, setInitialViewSet] = useState(false);
@@ -10,7 +10,7 @@ export function useInitialView(data: PriceDataPoint[], liquidityData: LiquidityD
   useEffect(() => {
     if (!initialViewSet && data && liquidityData && liquidityData.length > 0) {
       // Find current price tick index in the liquidity data
-      const currentPrice = data[data.length - 1]?.value || 0;
+      const currentPrice = data[data.length - 1]?.price || 0;
       const currentTickIndex = liquidityData.findIndex(d => 
         Math.abs(d.price0 - currentPrice) === Math.min(...liquidityData.map(item => Math.abs(item.price0 - currentPrice)))
       );
@@ -18,12 +18,15 @@ export function useInitialView(data: PriceDataPoint[], liquidityData: LiquidityD
       // Set initial zoom based on GBM confidence bands
       const currentPriceValue = liquidityData[currentTickIndex]?.price0 || currentPrice;
       
+      // Calculate mu and sigma from actual price data
+      const { mu, sigma } = calculateMuAndVolatility(data);
+      
       // Use GBM-based confidence bands with configurable time horizon
       const { pl: defaultMinPrice, pu: defaultMaxPrice } = computePriceBands({
         p0: currentPriceValue,
         T: Years.fromWeeks(timeHorizonWeeks),
-        sigma: DEFAULT_SIGMA,
-        mu: DEFAULT_MU,
+        sigma: sigma,
+        mu: mu,
         alpha: DEFAULT_ALPHA
       });
       


### PR DESCRIPTION
- Fix time horizon conversion to use 365.25 days/year for leap year accuracy
- Change volatility calculation from sample to population std 
- Use only last year of price data for more relevant volatility estimates at hour granularity
- Remove hardcoded volatility/drift defaults, always calculate from actual data
- Ensure mu (drift) parameter is always calculated from data, never defaults to 0
- Set confidence interval to 95% for all assets